### PR TITLE
Fix "READ THE DOCS" link

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,13 +40,9 @@ app({
         link({ href: "https://github.com/hyperapp/hyperapp/tree/master/src" }, [
           span("READ THE CODE")
         ]),
-        link(
-          {
-            href:
-              "https://github.com/hyperapp/hyperapp/blob/master/docs/README.md#documentation"
-          },
-          [span("READ THE DOCS")]
-        )
+        link({ href: "https://github.com/hyperapp/hyperapp/blob/master/README.md" }, [
+          span("READ THE DOCS")
+        ])
       ])
     ])
 })


### PR DESCRIPTION
This PR fixes the link for the "READ THE DOCS" button and also gives the code the same format as on the other `link`.