### PR TITLE
JS.ORG: no reasonable content

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-hyperapp.js.org
+


### PR DESCRIPTION
The JS.ORG service you are using is not meant to use as a direct redirect. That is more or less like not using the subdomain at all. #1345
Please add some content to the page and remove the redirect or free the subdomain.